### PR TITLE
Add `@typescript-eslint/member-delimiter-style` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,10 @@ module.exports = {
         "require-jsdoc": "off",
         "jsdoc/require-param": "off",
         "jsdoc/require-param-type": "off",
+        "@typescript-eslint/member-delimiter-style": ["error", {
+          "multiline": { "delimiter": "semi", "requireLast": true },
+          "singleline": { "delimiter": "semi", "requireLast": false }
+        }],
         "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false }],
         "@typescript-eslint/no-unused-vars": "error",
         "@typescript-eslint/no-var-requires": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.11",
+  "version": "1.0.12-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.12-dev.1",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.12-dev.1",
+  "version": "1.0.12",
   "description": "A standard ESLint config used across Ada projects",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.11",
+  "version": "1.0.12-dev.1",
   "description": "A standard ESLint config used across Ada projects",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Enforce semicolons as interface member delimiter. This rule is auto-fixable.

Test it out using published `1.0.12-dev.1` version.