### PR TITLE
Disable `react/require-default-props` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ module.exports = {
     "react/jsx-props-no-spreading": "off",
     "react/no-deprecated": ["warn"],
     "react/no-did-update-set-state": "off",
+    "react/require-default-props": "off",
     "react/static-property-placement": ["warn", "static public field"],
     "react/state-in-constructor": ["warn", "never"],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ada-support/eslint-config-ada",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "4.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "A standard ESLint config used across Ada projects",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Remove it in favour of props spread assignment, e.g.:
```tsx
interface Props {
  size?: "default" | "medium" | "large";
}

function Button ({ size = "default" }: Props) {
```