### PR TITLE
Disallow multiple EOF and BOF empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     "max-params": ["error", 4],
     "no-alert": "error",
     "no-console": ["error", { "allow": ["warn", "error"] }],
-    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1, "maxBOF": 0 }],
+    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 0, "maxBOF": 0 }],
     "no-underscore-dangle": "error",
     "no-unused-vars": "error",
     "no-use-before-define": "error",

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     "max-params": ["error", 4],
     "no-alert": "error",
     "no-console": ["error", { "allow": ["warn", "error"] }],
-    "no-multiple-empty-lines": ["error", { "max": 2 }],
+    "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1, "maxBOF": 0 }],
     "no-underscore-dangle": "error",
     "no-unused-vars": "error",
     "no-use-before-define": "error",
@@ -114,6 +114,7 @@ module.exports = {
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/indent": "off"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ada-support/eslint-config-ada",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ada-support/eslint-config-ada",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "A standard ESLint config used across Ada projects",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Also turn off `@typescript-eslint/no-unused-vars` for .js and .jsx to avoid duplicated errors.