### PR TITLE
Allow draftState to be reassigned (for immer)

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
     "no-alert": "error",
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0, "maxBOF": 0 }],
+    "no-param-reassign": ["error", { props: true, ignorePropertyModificationsFor: ["draftState"] }],
     "no-underscore-dangle": "error",
     "no-unused-vars": "error",
     "no-use-before-define": "error",


### PR DESCRIPTION
[Immer](https://immerjs.github.io/immer/) works by modifying a draft state. This causes a `no-param-reassign` linting error to be triggered. This change allows reassigning to arguments called "draftState". Another option would be to use `ignorePropertyModificationsForRegex = ["^draft"]` to allow more leeway in what that argument can be called.